### PR TITLE
Add PyTorch Test: Test Successfully Builds, but with Problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.0)
 project(kmeans_hacking)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -7,6 +7,11 @@ if (APPLE)
   add_compile_options(-Xclang -fnative-half-type)
 endif()
 
+find_package(Torch REQUIRED)
+
 add_executable(kmeans_hacking main.cpp util.cpp util.h constants.h kmeans.cpp kmeans.h)
+add_executable(pytorch_test pytorch_test.cpp util.cpp util.h constants.h kmeans.cpp kmeans.h)
+target_link_libraries(pytorch_test "${TORCH_LIBRARIES}")
+set_property(TARGET pytorch_test PROPERTY CXX_STANDARD 14)
 
 add_library(kmeans_hacking_lib SHARED util.cpp util.h constants.h kmeans.cpp kmeans.h)

--- a/pytorch_test.cpp
+++ b/pytorch_test.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <torch/torch.h>
+#include "constants.h"
+#include "kmeans.h"
+
+std::vector<char> get_the_bytes(std::string filename) {
+    std::ifstream input(filename, std::ios::binary);
+    std::vector<char> bytes(
+            (std::istreambuf_iterator<char>(input)),
+            (std::istreambuf_iterator<char>()));
+
+    input.close();
+    return bytes;
+}
+
+std::vector<float_type> tensor_to_vector(torch::Tensor tensor) {
+    std::vector<float_type> vec;
+    vec.reserve(tensor.size(0));
+
+    auto tensor_ac = tensor.accessor<float, 1>();
+    for (int i = 0; i < tensor.size(0); i++) {
+        auto this_item = tensor_ac[i];
+        // cast to float_type
+        auto casted = (float_type) this_item;
+        vec.push_back(casted);
+    }
+
+    return vec;
+}
+
+int main() {
+    std::vector<char> f = get_the_bytes("sample.pt");
+    torch::IValue x = torch::pickle_load(f);
+    torch::Tensor sample = x.toTensor();
+
+    long total_time = 0;
+    for (int i = 0; i < 768; i++) {
+        auto sample_0 = sample.index(
+                {torch::indexing::TensorIndex(0), torch::indexing::TensorIndex(torch::indexing::Slice()),
+                 torch::indexing::TensorIndex(i)});
+        // sample_0 with shape [49869]
+        auto data = tensor_to_vector(sample_0);
+        auto start = std::chrono::high_resolution_clock::now();
+        auto means = kmeans(data, 2, 3000);
+        auto end = std::chrono::high_resolution_clock::now();
+        total_time += std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+        for (auto &mean: means) {
+            std::cout << (float)mean << " ";
+        }
+        std::cout << means.size() << std::endl;
+    }
+
+    // print total time in second
+    std::cout << "total time: " << (total_time / (1000)) << "ms" << std::endl;
+
+    return 0;
+}

--- a/pytorch_test.h
+++ b/pytorch_test.h
@@ -1,0 +1,14 @@
+//
+// Created by Entropy Xu on 7/1/23.
+//
+
+#ifndef KMEANS_HACKING_PYTORCH_TEST_H
+#define KMEANS_HACKING_PYTORCH_TEST_H
+
+
+class pytorch_test {
+
+};
+
+
+#endif //KMEANS_HACKING_PYTORCH_TEST_H

--- a/pytorch_test.md
+++ b/pytorch_test.md
@@ -1,0 +1,20 @@
+# PyTorch Test
+
+## Installation
+1. Download the libtorch library from [here](https://github.com/mlverse/libtorch-mac-m1/releases/download/LibTorchOpenMP/libtorch-v2.0.0.zip).
+2. `unzip libtorch-v2.0.0.zip `
+3. `cmake . -DCMAKE_PREFIX_PATH=./libtorch -DCMAKE_BUILD_TYPE=Release`
+4. `make`
+
+## Benchmark Result: `2453` kmeans per second on M1 Macbook Pro (single thread)
+
+## Problem: Clustering Result seems to be wrong
+Here is a sample output of the `pytorch_test.cpp`
+```
+-0.101562 -0.078125 -0.0703125 -0.0546875 -0.046875 -0.03125 -0.0234375 -0.015625 -0.0078125 0.0078125 0.015625 0.03125 0.0390625 0.046875 0.0546875 0.0703125 16
+-10 -10 -0.265625 -0.257812 -0.25 -0.234375 -0.226562 -0.203125 -0.179688 -0.15625 -0.132812 -0.109375 -0.0859375 -0.0625 -0.0390625 0 16
+-10 -10 -10 -10 -10 -10 -10 -10 -10 -10 -10 -10 -10 -0.1875 -0.109375 -0.0546875 16
+```
+There are two problems:
+* The range of the data is from `-1.8262` to `0.9873`. Therefore, none of the centers are expected to be -10. However, the output gives many -10s.
+* Even though I set `k=32`, I still only get 16 returns from the `kmeans` function.


### PR DESCRIPTION
# PyTorch Test

## Installation
1. Download the libtorch library from [here](https://github.com/mlverse/libtorch-mac-m1/releases/download/LibTorchOpenMP/libtorch-v2.0.0.zip).
2. `unzip libtorch-v2.0.0.zip `
3. `cmake . -DCMAKE_PREFIX_PATH=./libtorch -DCMAKE_BUILD_TYPE=Release`
4. `make`

## Benchmark Result: `2453` kmeans per second on M1 Macbook Pro (single thread)

## Problem: Clustering Result seems to be wrong
Here is a sample output of the `pytorch_test.cpp`
```
-0.101562 -0.078125 -0.0703125 -0.0546875 -0.046875 -0.03125 -0.0234375 -0.015625 -0.0078125 0.0078125 0.015625 0.03125 0.0390625 0.046875 0.0546875 0.0703125 16
-10 -10 -0.265625 -0.257812 -0.25 -0.234375 -0.226562 -0.203125 -0.179688 -0.15625 -0.132812 -0.109375 -0.0859375 -0.0625 -0.0390625 0 16
-10 -10 -10 -10 -10 -10 -10 -10 -10 -10 -10 -10 -10 -0.1875 -0.109375 -0.0546875 16
```
There are two problems:
* The range of the data is from `-1.8262` to `0.9873`. Therefore, none of the centers are expected to be -10. However, the output gives many -10s.
* Even though I set `k=32`, I still only get 16 returns from the `kmeans` function.